### PR TITLE
Update ecr-pushimage.md

### DIFF
--- a/doc_source/ecr-pushimage.md
+++ b/doc_source/ecr-pushimage.md
@@ -63,6 +63,10 @@ Optional tag for the new image in the repository\. If not specified, ECR will as
 
 If checked, the task will check to see if the repository exists and if it does not, will attempt to create it\.
 
+### Force repository name to follow Docker naming conventions
+
+If enabled, the Docker repository name will be modified to follow Docker naming conventions. Converts upper case characters to lower case. Removes all characters except 0-9, -, . and _ .
+
 ### Image Tag Output Variable<a name="image-tag-output-variable"></a>
 
 The name of a build variable that will be created or updated with the pushed image reference\. The image tag will be of the form *aws\_account\_id\.dkr\.ecr\.region\.amazonaws\.com/imagename*, where **imagename** is in the format *repositoryname\[:tag\]* 


### PR DESCRIPTION
Added description for the option 'Force repository name to follow Docker naming conventions'.

*Issue #, if available:*

*Description of changes:*

Updated the ecr-pushimage documentation to include the most recent changes to the ECR Push Image task [Add enforceDockerNamingConventions to ECRPushImage](https://github.com/aws/aws-toolkit-azure-devops/commit/bf46d90007165c87bffae78e29bc36aee7ef42f8).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
