### PR TITLE
Update list of permissions required by Elastic Beanstalk Deploy Appli…

### DIFF
--- a/doc_source/elastic-beanstalk-deploy.md
+++ b/doc_source/elastic-beanstalk-deploy.md
@@ -82,11 +82,19 @@ Optional variable name to which the version label for the revision will be store
 ## Task Permissions<a name="task-permissions"></a>
 
 This task requires permissions to call the following AWS service APIs \(depending on selected task options, not all APIs may be used\):
++ autoscaling:DescribeScalingActivities
++ autoscaling:DescribeAutoScalingGroups
++ autoscaling:ResumeProcesses
++ autoscaling:SuspendProcesses
++ cloudformation:DescribeStackResource
++ cloudformation:DescribeStackResources
++ cloudformation:GetTemplate
 + elasticbeanstalk:CreateApplicationVersion
 + elasticbeanstalk:CreateStorageLocation
 + elasticbeanstalk:DescribeApplications
 + elasticbeanstalk:DescribeEnvironments
 + elasticbeanstalk:DescribeEvents
 + elasticbeanstalk:UpdateEnvironment
++ elasticloadbalancing:RegisterInstancesWithLoadBalancer
 
 The task also requires permissions to upload your application content to the specified Amazon S3 bucket\. Depending on the size of the application bundle, either PutObject or the S3 multi\-part upload APIs may be used\.


### PR DESCRIPTION
…cation task

This longer list of permissions is provided in the console log output when running the Elastic Beanstalk Deploy Application task in Azure DevOps with the exception of cloudformation:GetTemplate which throws the following error when it is missing:

[error]InsufficientPrivilegesException: User: (removed) is not authorized to perform: cloudformation:GetTemplate on resource: (removed) because no identity-based policy allows the cloudformation:GetTemplate action

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
